### PR TITLE
Feat/add application codes in app memos

### DIFF
--- a/public/js/app/components/ActionModalCourseRounds.jsx
+++ b/public/js/app/components/ActionModalCourseRounds.jsx
@@ -43,7 +43,7 @@ function ActionModalCourseRounds(props) {
   })
 
   const [memo, setMemo] = useState(() => uniqueMemos.find(m => m.memoEndPoint === chosenMemoEndPoint) || {})
-  const { ladokRoundIds, memoCommonLangAbbr, memoEndPoint, memoName, semester, status, version } = memo
+  const { applicationCodes, memoCommonLangAbbr, memoEndPoint, memoName, semester, status, version } = memo
 
   const [roundGroups, setRoundsGroup] = useState({ allRounds: [], availableRounds: [], showSaveBtn: false })
   const { allRounds, availableRounds, showSaveBtn } = roundGroups
@@ -92,10 +92,10 @@ function ActionModalCourseRounds(props) {
     return checkedRounds
   }
 
-  const _koppsInfoForChecked = sortedRoundIds => {
+  const _koppsInfoForChecked = sortedApplicationCodes => {
     const sortedKoppsInfo = []
-    for (let i = 0; i < sortedRoundIds.length; i++) {
-      sortedKoppsInfo.push(allRounds.find(({ ladokRoundId }) => sortedRoundIds[i] === ladokRoundId))
+    for (let i = 0; i < sortedApplicationCodes.length; i++) {
+      sortedKoppsInfo.push(allRounds.find(round => sortedApplicationCodes[i] === round.applicationCodes[0]))
     }
     return sortedKoppsInfo
   }
@@ -105,18 +105,18 @@ function ActionModalCourseRounds(props) {
     const isPublished = status === 'published' || Number(version) > FIRST_VERSION
 
     if (checkedRounds.length > 0) {
-      const sortedRoundIds = await [...ladokRoundIds, ...checkedRounds].sort()
-      const sortedKoppsInfo = await _koppsInfoForChecked(sortedRoundIds)
+      const sortedApplicationCodes = await [...applicationCodes, ...checkedRounds].sort()
+      const sortedKoppsInfo = await _koppsInfoForChecked(sortedApplicationCodes)
 
       const newMemoName = sortedKoppsInfo.map(round => combineMemoName(round, semester, memoCommonLangAbbr)).join(', ')
       const firstDraft = version === FIRST_VERSION && status === 'draft'
-      const newMemoEndPoint = firstDraft ? courseCode + semester + '-' + sortedRoundIds.join('-') : memoEndPoint
+      const newMemoEndPoint = firstDraft ? courseCode + semester + '-' + sortedApplicationCodes.join('-') : memoEndPoint
 
       const newInfo = {
         courseCode,
         memoName: newMemoName,
         memoEndPoint: newMemoEndPoint,
-        ladokRoundIds: sortedRoundIds,
+        applicationCodes: sortedApplicationCodes,
       }
       const apiAction = isPublished ? 'create-draft' : 'draft-updates'
       const urlUpdateOrCreate = `${SERVICE_URL.API}${apiAction}/${courseCode}/${memoEndPoint}`
@@ -173,18 +173,21 @@ function ActionModalCourseRounds(props) {
           <Label htmlFor="choose-rounds-list">{info.chooseRound.addRounds.infoText}</Label>
           <Form className={`Available--Rounds--To--Add ${alert && alert.isOpen ? 'error-area' : ''}`}>
             {availableRounds.map(round => (
-              <FormGroup className="form-check" id="choose-rounds-list" key={'add' + round.ladokRoundId}>
+              <FormGroup className="form-check" id="choose-rounds-list" key={'add' + round.applicationCodes[0]}>
                 <Input
                   data-testid="checkbox-add-rounds-to-saved-memo"
                   type="checkbox"
-                  id={'addNew' + round.ladokRoundId}
+                  id={'addNew' + round.applicationCodes[0]}
                   name="addNew"
                   className="addNewRounds"
-                  value={round.ladokRoundId}
+                  value={round.applicationCodes[0]}
                   defaultChecked={false}
                   disabled={!canMerge(memoCommonLangAbbr, round)}
                 />
-                <Label data-testid="label-checkbox-add-rounds-to-saved-memo" htmlFor={'addNew' + round.ladokRoundId}>
+                <Label
+                  data-testid="label-checkbox-add-rounds-to-saved-memo"
+                  htmlFor={'addNew' + round.applicationCodes[0]}
+                >
                   {`${combineMemoName(round, semester, langAbbr)}.`}
                   {(!canMerge(memoCommonLangAbbr, round) && <i>{extraInfo.cannotMergeLanguage}</i>) || ''}
                 </Label>

--- a/public/js/app/components/ControlPanel.jsx
+++ b/public/js/app/components/ControlPanel.jsx
@@ -5,9 +5,8 @@ import React from 'react'
 import { Alert, Row, Col, Button } from 'reactstrap'
 import { ActionModalButton } from '@kth/kth-reactstrap/dist/components/utbildningsinfo'
 import PropTypes from 'prop-types'
-import ActionModalCourseRounds from './ActionModalCourseRounds'
-
 import i18n from '../../../../i18n'
+import ActionModalCourseRounds from './ActionModalCourseRounds'
 
 const colWidthByProgress = {
   1: { firstCol: '6', secondCol: '0', thirdCol: '6' },

--- a/public/js/app/pages/CreateNewMemo.jsx
+++ b/public/js/app/pages/CreateNewMemo.jsx
@@ -62,7 +62,7 @@ function CreateNewMemo(props) {
   const [chosen, setChosen] = useState({
     existingDraftEndPoint: initialMemoEndPoint || '',
     newMemoName: '',
-    sortedRoundIds: rounds || [],
+    sortedApplicationCodes: rounds || [],
     sortedKoppsInfo: [], // use it for next step
   })
   const [alert, setAlert] = useState({
@@ -95,13 +95,13 @@ function CreateNewMemo(props) {
   }, [semester])
 
   const _cleanUpPrevCheckboxesState = memoEndPoint => {
-    const { sortedRoundIds } = chosen
-    emptyCheckboxesByIds(sortedRoundIds, 'new')
+    const { sortedApplicationCodes } = chosen
+    emptyCheckboxesByIds(sortedApplicationCodes, 'new')
     setAction(memoEndPoint ? 'continue' : '')
     setChosen({
       existingDraftEndPoint: memoEndPoint || '',
       newMemoName: '',
-      sortedRoundIds: [],
+      sortedApplicationCodes: [],
       sortedKoppsInfo: [],
     })
   }
@@ -145,7 +145,7 @@ function CreateNewMemo(props) {
     const { checked, value } = event.target
     const { existingDraftEndPoint } = chosen
     if (existingDraftEndPoint) uncheckRadioById(existingDraftEndPoint)
-    const { sortedRoundIds, sortedKoppsInfo } = checked
+    const { sortedApplicationCodes, sortedKoppsInfo } = checked
       ? sortRoundAndKoppsInfo(chosenRoundObj, chosen)
       : removeAndSortRoundAndInfo(value, chosen)
 
@@ -160,7 +160,7 @@ function CreateNewMemo(props) {
       memoCommonLangAbbr,
       existingDraftEndPoint: '',
       newMemoName,
-      sortedRoundIds,
+      sortedApplicationCodes,
       sortedKoppsInfo,
     })
   }
@@ -203,7 +203,7 @@ function CreateNewMemo(props) {
   }
 
   const onSubmitNew = async () => {
-    const { existingDraftEndPoint, newMemoName, memoCommonLangAbbr, sortedRoundIds } = chosen
+    const { existingDraftEndPoint, newMemoName, memoCommonLangAbbr, sortedApplicationCodes } = chosen
 
     if (action === 'copy' && !copyFromMemoEndPoint) {
       // if chosen to copy but not a template to copy from
@@ -212,7 +212,7 @@ function CreateNewMemo(props) {
       // Draft exists just go to next step
       const continueToEditorUrl = `${SERVICE_URL.courseMemoAdmin}${courseCode}/${existingDraftEndPoint}`
       window.location = continueToEditorUrl
-    } else if (sortedRoundIds.length > 0 && !existingDraftEndPoint) {
+    } else if (sortedApplicationCodes.length > 0 && !existingDraftEndPoint) {
       const courseTitle = combinedCourseName(courseCode, course, memoCommonLangAbbr)
 
       // Create new draft from chosen semester rounds
@@ -221,9 +221,9 @@ function CreateNewMemo(props) {
         courseTitle,
         memoName: newMemoName,
         memoCommonLangAbbr,
-        ladokRoundIds: sortedRoundIds,
+        applicationCodes: sortedApplicationCodes,
         languageOfInstructions: chosen.languageOfInstructions,
-        memoEndPoint: courseCode + semester + '-' + sortedRoundIds.join('-'),
+        memoEndPoint: courseCode + semester + '-' + sortedApplicationCodes.join('-'),
         semester,
       }
 
@@ -377,18 +377,21 @@ function CreateNewMemo(props) {
                         data-testid="form-choose-new"
                         className="form-check"
                         id="choose-from-rounds-list"
-                        key={'new' + round.ladokRoundId}
+                        key={'new' + round.applicationCodes[0]}
                       >
                         <Input
                           type="checkbox"
                           data-testid="checkbox-choose-available-round"
-                          id={'new' + round.ladokRoundId}
+                          id={'new' + round.applicationCodes[0]}
                           name="chooseNew"
-                          value={round.ladokRoundId}
+                          value={round.applicationCodes[0]}
                           onClick={event => onChoiceOfAvailableRounds(event, round)}
                           defaultChecked={false}
                         />
-                        <Label htmlFor={'new' + round.ladokRoundId} data-testid="label-checkbox-choose-available-round">
+                        <Label
+                          htmlFor={'new' + round.applicationCodes[0]}
+                          data-testid="label-checkbox-choose-available-round"
+                        >
                           {/* Namegiving according to user interface language */}
                           {combineMemoName(round, semester, langAbbr)}
                         </Label>
@@ -403,7 +406,7 @@ function CreateNewMemo(props) {
               )}
             </div>
           </Col>
-          {chosen.sortedRoundIds.length > 0 && action !== 'continue' && (
+          {chosen.sortedApplicationCodes.length > 0 && action !== 'continue' && (
             <Col className="right-block-for-extra">
               {/* CREATE FROM EMPTY OF COPY FROM */}
               <div className="Start--Creating--From--Template--Or--Copy">
@@ -477,7 +480,7 @@ function CreateNewMemo(props) {
         <p data-testid="actionType">{action}</p>
         <p data-testid="newMemoName">{chosen.newMemoName}</p>
         <p data-testid="memoCommonLangAbbr">{chosen.memoCommonLangAbbr}</p>
-        <p data-testid="sortedRoundIds">{chosen.sortedRoundIds.join(',')}</p>
+        <p data-testid="sortedApplicationCodes">{chosen.sortedApplicationCodes.join(',')}</p>
       </div>
     </Container>
   )

--- a/public/js/app/pages/MemoEditingContainer.jsx
+++ b/public/js/app/pages/MemoEditingContainer.jsx
@@ -52,7 +52,7 @@ function MemoContainer(props) {
     semester,
   } = store
 
-  if (!memoData.ladokRoundIds)
+  if (!memoData.applicationCodes)
     return <AlertMissingDraft langAbbr={userLangAbbr} langIndex={userLangIndex} courseCode={courseCode} />
 
   const { initialActiveTab } = props // used for test

--- a/public/js/app/pages/PreviewContainer.jsx
+++ b/public/js/app/pages/PreviewContainer.jsx
@@ -195,7 +195,7 @@ function PreviewContainer(props) {
     courseCode,
     courseTitle,
     semester = '',
-    ladokRoundIds,
+    applicationCodes,
     memoCommonLangAbbr,
     memoEndPoint,
     memoName,
@@ -203,7 +203,7 @@ function PreviewContainer(props) {
     syllabusValid,
   } = memoData
 
-  if (!ladokRoundIds) return <AlertMissingDraft langAbbr={langAbbr} langIndex={langIndex} courseCode={courseCode} />
+  if (!applicationCodes) return <AlertMissingDraft langAbbr={langAbbr} langIndex={langIndex} courseCode={courseCode} />
 
   const isDraftOfPublished = Number(version) > FIRST_VERSION
 
@@ -232,7 +232,7 @@ function PreviewContainer(props) {
   let active = false
   let courseMemoItems = store.memoDatas.map(m => {
     const id = m.memoEndPoint
-    const label = concatMemoName(m.semester, m.ladokRoundIds, m.memoCommonLangAbbr)
+    const label = concatMemoName(m.semester, m.applicationCodes, m.memoCommonLangAbbr)
     // memoEndPoint is currently displayed
     active = m.memoEndPoint === memoEndPoint
     return {
@@ -246,7 +246,7 @@ function PreviewContainer(props) {
   if (!active) {
     courseMemoItems.push({
       id: store.memoEndPoint,
-      label: concatMemoName(semester, ladokRoundIds, memoCommonLangAbbr),
+      label: concatMemoName(semester, applicationCodes, memoCommonLangAbbr),
       active: true,
       url: `/kurs-pm/${courseCode}/${memoEndPoint}`,
     })
@@ -279,7 +279,7 @@ function PreviewContainer(props) {
         const publishType = isDraftOfPublished ? 'pub_changed' : 'pub'
         window.location = `${ADMIN_URL}${courseCode}?serv=pmdata&event=${publishType}&ver=${versionStr}&term=${semester}&name=${encodeURIComponent(
           memoName
-        )}&memoendpoint=${memoEndPoint}&ladokRound=${ladokRoundIds.join('-')}`
+        )}&memoendpoint=${memoEndPoint}&ladokRound=${applicationCodes.join('-')}`
       })
       // eslint-disable-next-line no-console
       .catch(error => console.log(error))
@@ -334,7 +334,7 @@ function PreviewContainer(props) {
         </Col>
         <Col lg="9">
           <CourseHeader
-            courseMemo={concatMemoName(semester, ladokRoundIds, memoCommonLangAbbr)}
+            courseMemo={concatMemoName(semester, applicationCodes, memoCommonLangAbbr)}
             courseCode={courseCode}
             courseTitle={courseTitle}
             labels={courseHeaderLabels}

--- a/public/js/app/stores/createApplicationStore.js
+++ b/public/js/app/stores/createApplicationStore.js
@@ -244,7 +244,7 @@ async function _filterOutUsedRounds(usedRoundsThisTerm, chosenSemester, koppsLas
   return (
     (thisTerm &&
       thisTerm.rounds &&
-      (await thisTerm.rounds.filter(r => !usedRoundsThisTerm.includes(r.ladokRoundId)).reverse())) ||
+      (await thisTerm.rounds.filter(r => !usedRoundsThisTerm.includes(r.applicationCodes[0])).reverse())) ||
     []
   )
 }

--- a/public/js/app/util/helpers.js
+++ b/public/js/app/util/helpers.js
@@ -38,11 +38,11 @@ export const getDateFormat = (date, language) => {
 }
 
 export const combineMemoName = (roundInfo, semester, langAbbr = 'sv') => {
-  const { firstTuitionDate, shortName, ladokRoundId, language } = roundInfo
+  const { firstTuitionDate, shortName, language, applicationCodes } = roundInfo
   const langIndex = langAbbr === 'en' ? 0 : 1
   const { extraInfo } = i18n.messages[langIndex]
 
-  const seasonOrShortName = shortName ? shortName + ' ' : `${seasonStr(langIndex, semester)}-${ladokRoundId}`
+  const seasonOrShortName = shortName ? shortName + ' ' : `${seasonStr(langIndex, semester)}-${applicationCodes[0]}`
 
   const startDateAndLanguage = `(${extraInfo.labelStartDate} ${getDateFormat(firstTuitionDate, langAbbr)}, ${
     language[langAbbr]
@@ -51,12 +51,12 @@ export const combineMemoName = (roundInfo, semester, langAbbr = 'sv') => {
 }
 
 // "Kurs-pm "+ [termin] "-" [kurstillfälleskoder separerade med bindestreck]
-// label + formatted semester + ladokRoundIds
+// label + formatted semester + applicationCodes
 
-export const concatMemoName = (semester, ladokRoundIds, langAbbr = 'sv') => {
+export const concatMemoName = (semester, applicationCodes, langAbbr = 'sv') => {
   const langIndex = langAbbr === 'en' ? 0 : 1
   const { memoLabel } = i18n.messages[langIndex].messages
-  return `${memoLabel} ${seasonStr(i18n.messages[langIndex].extraInfo, semester)}-${ladokRoundIds.join('-')}`
+  return `${memoLabel} ${seasonStr(i18n.messages[langIndex].extraInfo, semester)}-${applicationCodes.join('-')}`
 }
 
 export const fetchThisTermRounds = async (miniKoppsObj, memo) => {
@@ -74,9 +74,9 @@ export const uncheckRadioById = chosenId => {
   }
 }
 
-export const emptyCheckboxesByIds = (sortedRoundIds, startOfId) => {
-  sortedRoundIds.map(ladokRoundId => {
-    const checkboxId = `${startOfId}${ladokRoundId}`
+export const emptyCheckboxesByIds = (sortedApplicationCodes, startOfId) => {
+  sortedApplicationCodes.forEach(applicationCode => {
+    const checkboxId = `${startOfId}${applicationCode}`
     document.getElementById(checkboxId).checked = false
   })
 }
@@ -91,21 +91,21 @@ export const emptyCheckboxes = className => {
 }
 
 export const sortRoundAndKoppsInfo = (roundKopps, prevSortedInfo) => {
-  const { ladokRoundId } = roundKopps
-  const { sortedRoundIds, sortedKoppsInfo } = prevSortedInfo
-  sortedRoundIds.push(ladokRoundId)
-  const sortedRounds = sortedRoundIds.sort()
-  const addIndex = sortedRounds.indexOf(ladokRoundId)
+  const { applicationCodes } = roundKopps
+  const { sortedApplicationCodes, sortedKoppsInfo } = prevSortedInfo
+  sortedApplicationCodes.push(applicationCodes[0])
+  const sortedRounds = sortedApplicationCodes.sort()
+  const addIndex = sortedRounds.indexOf(applicationCodes[0])
   sortedKoppsInfo.splice(addIndex, 0, roundKopps)
-  return { sortedRoundIds, sortedKoppsInfo }
+  return { sortedApplicationCodes, sortedKoppsInfo }
 }
 
-export const removeAndSortRoundAndInfo = (ladokRoundId, prevSortedInfo) => {
-  const { sortedRoundIds, sortedKoppsInfo } = prevSortedInfo
-  const removeIndex = sortedRoundIds.indexOf(ladokRoundId)
-  sortedRoundIds.splice(removeIndex, 1)
+export const removeAndSortApplicationAndInfo = (applicationCode, prevSortedInfo) => {
+  const { sortedApplicationCodes, sortedKoppsInfo } = prevSortedInfo
+  const removeIndex = sortedApplicationCodes.indexOf(applicationCode)
+  sortedApplicationCodes.splice(removeIndex, 1)
   sortedKoppsInfo.splice(removeIndex, 1)
-  return { sortedRoundIds, sortedKoppsInfo }
+  return { sortedApplicationCodes, sortedKoppsInfo }
 }
 
 export const fetchParameters = props => {

--- a/server/controllers/choiceOptionsCtrl.js
+++ b/server/controllers/choiceOptionsCtrl.js
@@ -11,6 +11,8 @@ const serverPaths = require('../server').getPaths()
 const { browser, server } = require('../configuration')
 const { getMemoApiData, changeMemoApiData } = require('../kursPmDataApi')
 const i18n = require('../../i18n')
+// No need to merge this method to master
+const { fetchAllMemosAndUpdateMemoWithApplicationCodes } = require('./updateMemosCtrl')
 
 // eslint-disable-next-line consistent-return
 async function getUsedDrafts(req, res, next) {
@@ -55,7 +57,8 @@ async function getCourseOptionsPage(req, res, next) {
     const applicationStore = createStore()
     applicationStore.setBrowserConfig(browser, serverPaths, apis, server.hostUrl)
     applicationStore.doSetLanguageIndex(lang)
-
+    // No need to merge this method to master
+    await fetchAllMemosAndUpdateMemoWithApplicationCodes()
     applicationStore.miniKoppsObj = await getKoppsCourseRoundTerms(courseCode)
     const memoParams = getMemosParams(courseCode, applicationStore.miniKoppsObj)
 

--- a/server/controllers/choiceOptionsCtrl.js
+++ b/server/controllers/choiceOptionsCtrl.js
@@ -12,7 +12,10 @@ const { browser, server } = require('../configuration')
 const { getMemoApiData, changeMemoApiData } = require('../kursPmDataApi')
 const i18n = require('../../i18n')
 // No need to merge this method to master
-const { fetchAllMemosAndUpdateMemoWithApplicationCodes } = require('./updateMemosCtrl')
+const {
+  fetchAllMemosAndUpdateMemoWithApplicationCodes,
+  fetchAllMemoFilesAndUpdateWithApplicationCodes,
+} = require('./updateMemosCtrl')
 
 // eslint-disable-next-line consistent-return
 async function getUsedDrafts(req, res, next) {
@@ -58,6 +61,7 @@ async function getCourseOptionsPage(req, res, next) {
     applicationStore.setBrowserConfig(browser, serverPaths, apis, server.hostUrl)
     applicationStore.doSetLanguageIndex(lang)
     // No need to merge this method to master
+    await fetchAllMemoFilesAndUpdateWithApplicationCodes()
     await fetchAllMemosAndUpdateMemoWithApplicationCodes()
     applicationStore.miniKoppsObj = await getKoppsCourseRoundTerms(courseCode)
     const memoParams = getMemosParams(courseCode, applicationStore.miniKoppsObj)

--- a/server/controllers/choiceOptionsCtrl.js
+++ b/server/controllers/choiceOptionsCtrl.js
@@ -61,8 +61,8 @@ async function getCourseOptionsPage(req, res, next) {
     applicationStore.setBrowserConfig(browser, serverPaths, apis, server.hostUrl)
     applicationStore.doSetLanguageIndex(lang)
     // No need to merge this method to master
-    await fetchAllMemoFilesAndUpdateWithApplicationCodes()
-    await fetchAllMemosAndUpdateMemoWithApplicationCodes()
+    applicationStore.memoFilesExportMap = await fetchAllMemoFilesAndUpdateWithApplicationCodes()
+    applicationStore.memosExportMap = await fetchAllMemosAndUpdateMemoWithApplicationCodes()
     applicationStore.miniKoppsObj = await getKoppsCourseRoundTerms(courseCode)
     const memoParams = getMemosParams(courseCode, applicationStore.miniKoppsObj)
 

--- a/server/controllers/updateMemosCtrl.js
+++ b/server/controllers/updateMemosCtrl.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const { safeGet } = require('safe-utils')
+const log = require('@kth/log')
+const { getKoppsCourseRoundTerms, getAllCourseCodes, getApplicationFromLadokUID } = require('../koppsApi')
+const { getMemoApiData, changeMemoApiData } = require('../kursPmDataApi')
+
+async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
+  const courseCodes = await getAllCourseCodes()
+  let totalMemosToUpdate = 0
+  let totalCoursesFetchedFromKopps = 0
+  let totalApplicationCodesFetchedFromKopps = 0
+  if (courseCodes && courseCodes.length > 0) {
+    totalCoursesFetchedFromKopps = courseCodes.length
+    for await (const courseCode of courseCodes) {
+      const memoData = await getMemoApiData('getAllMemosByCourseCode', {
+        courseCode,
+      })
+      if (memoData && memoData.length > 0) {
+        const { lastTermsInfo } = await getKoppsCourseRoundTerms(courseCode, false)
+        if (lastTermsInfo && lastTermsInfo.length > 0) {
+          for await (const { ladokRoundIds, semester, applicationCodes, memoEndPoint } of memoData) {
+            for await (const { rounds, term } of lastTermsInfo) {
+              if (semester.toString() === term.toString()) {
+                for await (const ladokRoundId of ladokRoundIds) {
+                  const round = rounds.find(x => x.ladokRoundId.toString() === ladokRoundId.toString())
+                  if (round) {
+                    const { ladokUID } = round
+                    if (ladokUID && ladokUID !== '') {
+                      const { application_code } = await getApplicationFromLadokUID(ladokUID)
+                      totalApplicationCodesFetchedFromKopps++
+                      const applicationCode = applicationCodes.find(x => x === application_code)
+                      if (!applicationCode) {
+                        applicationCodes.push(application_code)
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            const apiResponse = await changeMemoApiData(
+              'updatedMemoById',
+              { memoEndPoint, courseCode, semester },
+              {
+                applicationCodes,
+              }
+            )
+            if (safeGet(() => apiResponse.message)) {
+              log.debug('Error from API trying to update a new draft: ', apiResponse.message)
+            }
+            log.info('New memo draft was created in kurs-pm-data-api for course memo with memoEndPoint:', memoEndPoint)
+            totalMemosToUpdate++
+          }
+        }
+      }
+    }
+    log.debug('All memos have been updated with application codes.', {
+      totalApplicationCodesFetchedFromKopps,
+      totalCoursesFetchedFromKopps,
+      totalMemosToUpdate,
+    })
+  }
+}
+
+module.exports = {
+  fetchAllMemosAndUpdateMemoWithApplicationCodes: _fetchAllMemosAndUpdateMemoWithApplicationCodes,
+}

--- a/server/controllers/updateMemosCtrl.js
+++ b/server/controllers/updateMemosCtrl.js
@@ -61,9 +61,9 @@ function _getAllUniqueCourseCodesFromData(data) {
 
 async function _getCourseRoundTermMap(courseCodes) {
   const courseRoundTermMap = new Map()
-  log.debug('Total courses to fetch course rounds', courseCodes.length)
+  log.info('Total courses to fetch course rounds', courseCodes.length)
   for await (const courseCode of courseCodes) {
-    log.debug('Fetching course round terms for course: ', courseCode)
+    log.info('Fetching course round terms for course: ', courseCode)
     const { lastTermsInfo } = await getKoppsCourseRoundTerms(courseCode, false)
     courseRoundTermMap.set(courseCode, lastTermsInfo)
   }
@@ -103,7 +103,7 @@ async function _fetchAllMemoFilesAndUpdateWithApplicationCodes() {
               { applicationCode }
             )
             if (safeGet(() => apiResponse.message)) {
-              log.debug('Error from API trying to update a new memo file: ', apiResponse.message)
+              log.info('Error from API trying to update a new memo file: ', apiResponse.message)
               failedMemoFilesToUpdate.push(memoFile)
             } else {
               memoFilesUpdated.push(memoFile)
@@ -118,10 +118,10 @@ async function _fetchAllMemoFilesAndUpdateWithApplicationCodes() {
       }
     }
   }
-  log.debug('Total fetced memos files', allMemoFiles.length, allMemoFiles)
-  log.debug('Total memo update calls', memoFilesUpdated.length, memoFilesUpdated)
-  log.debug('Total failed memos files', failedMemoFilesToUpdate.length, failedMemoFilesToUpdate)
-  log.debug(
+  log.info('Total fetced memos files', allMemoFiles.length, allMemoFiles)
+  log.info('Total memo update calls', memoFilesUpdated.length, memoFilesUpdated)
+  log.info('Total failed memos files', failedMemoFilesToUpdate.length, failedMemoFilesToUpdate)
+  log.info(
     'Total memo files without application codes',
     memoFilesWithOutApplicationCodes,
     memoFilesWithOutApplicationCodes
@@ -171,7 +171,7 @@ async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
               { applicationCodes, ladokRoundIds }
             )
             if (safeGet(() => apiResponse.message)) {
-              log.debug('Error from API trying to update a new draft: ', apiResponse.message)
+              log.info('Error from API trying to update a new draft: ', apiResponse.message)
               failedMemosToUpdate.push(memo)
             } else {
               memosUpdated.push(memo)
@@ -189,10 +189,10 @@ async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
       }
     }
   }
-  log.debug('Total fetced memos', memoData.length, memoData)
-  log.debug('Total memos updated', memosUpdated.length, memosUpdated)
-  log.debug('Total failed memos', failedMemosToUpdate.length, failedMemosToUpdate)
-  log.debug('Total memo without application codes', memosWithOutApplicationCodes, memosWithOutApplicationCodes)
+  log.info('Total fetced memos', memoData.length, memoData)
+  log.info('Total memos updated', memosUpdated.length, memosUpdated)
+  log.info('Total failed memos', failedMemosToUpdate.length, failedMemosToUpdate)
+  log.info('Total memo without application codes', memosWithOutApplicationCodes, memosWithOutApplicationCodes)
   if (failedMemosToUpdate.length > 0) {
     _exportToCsv('failed_memos.csv', failedMemosToUpdate)
   }

--- a/server/controllers/updateMemosCtrl.js
+++ b/server/controllers/updateMemosCtrl.js
@@ -19,7 +19,15 @@ async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
       if (memoData && memoData.length > 0) {
         const { lastTermsInfo } = await getKoppsCourseRoundTerms(courseCode, false)
         if (lastTermsInfo && lastTermsInfo.length > 0) {
-          for await (const { ladokRoundIds, semester, applicationCodes, memoEndPoint } of memoData) {
+          for await (const {
+            ladokRoundIds,
+            semester,
+            applicationCodes,
+            memoEndPoint,
+            memoName,
+            status,
+            version,
+          } of memoData) {
             const lastTermInfo = lastTermsInfo.find(x => x.term.toString() === semester.toString())
             if (lastTermInfo) {
               const { rounds } = lastTermInfo
@@ -42,7 +50,7 @@ async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
             }
             const apiResponse = await changeMemoApiData(
               'updatedMemoById',
-              { memoEndPoint, courseCode, semester },
+              { memoName, memoEndPoint, courseCode, semester, status, version },
               {
                 applicationCodes,
               }

--- a/server/controllers/updateMemosCtrl.js
+++ b/server/controllers/updateMemosCtrl.js
@@ -27,11 +27,16 @@ async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
                   if (round) {
                     const { ladokUID } = round
                     if (ladokUID && ladokUID !== '') {
-                      const { application_code } = await getApplicationFromLadokUID(ladokUID)
+                      if (courseCode === 'SF1626' && ladokRoundId === '7' && semester === '20211') {
+                        log.info('Check')
+                      }
+                      const { application_code, round_number } = await getApplicationFromLadokUID(ladokUID)
                       totalApplicationCodesFetchedFromKopps++
-                      const applicationCode = applicationCodes.find(x => x === application_code)
-                      if (!applicationCode) {
-                        applicationCodes.push(application_code)
+                      if (round_number.toString() === ladokRoundId.toString()) {
+                        const applicationCode = applicationCodes.find(x => x.toString() === application_code.toString())
+                        if (!applicationCode) {
+                          applicationCodes.push(application_code)
+                        }
                       }
                     }
                   }

--- a/server/controllers/updateMemosCtrl.js
+++ b/server/controllers/updateMemosCtrl.js
@@ -19,15 +19,7 @@ async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
       if (memoData && memoData.length > 0) {
         const { lastTermsInfo } = await getKoppsCourseRoundTerms(courseCode, false)
         if (lastTermsInfo && lastTermsInfo.length > 0) {
-          for await (const {
-            ladokRoundIds,
-            semester,
-            applicationCodes,
-            memoEndPoint,
-            memoName,
-            status,
-            version,
-          } of memoData) {
+          for await (const { ladokRoundIds, semester, applicationCodes, memoEndPoint, _id } of memoData) {
             const lastTermInfo = lastTermsInfo.find(x => x.term.toString() === semester.toString())
             if (lastTermInfo) {
               const { rounds } = lastTermInfo
@@ -50,7 +42,7 @@ async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
             }
             const apiResponse = await changeMemoApiData(
               'updatedMemoById',
-              { memoName, memoEndPoint, courseCode, semester, status, version },
+              { _id },
               {
                 applicationCodes,
               }

--- a/server/controllers/updateMemosCtrl.js
+++ b/server/controllers/updateMemosCtrl.js
@@ -86,7 +86,7 @@ async function _fetchAllMemoFilesAndUpdateWithApplicationCodes() {
                 }
                 log.info('New memo file was created in kurs-pm-data-api for course memo with id:', _id)
               } catch (error) {
-                log.error('Error is updating memo file with id: ', _id)
+                log.error('Error in updating memo file ', error)
                 failedMemoFilesToUpdate.push(memoFile)
               }
             } else {
@@ -184,7 +184,7 @@ async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
                   )
                 }
               } catch (error) {
-                log.error('Error is updating memo : ', memo)
+                log.error('Error in updating memo : ', error)
                 failedMemosToUpdate.push(memo)
               }
             } else {

--- a/server/controllers/updateMemosCtrl.js
+++ b/server/controllers/updateMemosCtrl.js
@@ -55,6 +55,9 @@ async function _fetchAllMemoFilesAndUpdateWithApplicationCodes() {
                       const { application_code, round_number } = await getApplicationFromLadokUID(ladokUID)
                       if (round_number.toString() === koppsRoundId.toString()) {
                         applicationCode = application_code
+                      } else {
+                        log.debug('Application code not matched for ', memoFile, { application_code })
+                        memoFilesWithOutApplicationCodes.push(memoFile)
                       }
                     } catch (error) {
                       log.error('Error in getting application code of memo file: ', memoFile)
@@ -148,7 +151,7 @@ async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
                       if (round_number.toString() === ladokRoundId.toString()) {
                         const applicationCode = applicationCodes.find(x => x.toString() === application_code.toString())
                         if (!applicationCode) {
-                          log.info('Applition code pushed to memo: ', { applicationCode }, memo)
+                          log.info('Applition code pushed to memo: ', { application_code }, memo)
                           applicationCodes.push(application_code)
                         } else {
                           log.debug('Application Code already exist in memo', { applicationCode })

--- a/server/controllers/updateMemosCtrl.js
+++ b/server/controllers/updateMemosCtrl.js
@@ -71,8 +71,9 @@ async function _getCourseRoundTermMap(courseCodes) {
 }
 
 async function _fetchAllMemoFilesAndUpdateWithApplicationCodes() {
-  const allMemoFiles = await getMemoApiData('getStoredMemoPdfList', null)
   const failedMemoFilesToUpdate = []
+  const memoFilesUpdated = []
+  const allMemoFiles = await getMemoApiData('getStoredMemoPdfList', null)
   if (allMemoFiles && allMemoFiles.length > 0) {
     const courseCodes = _getAllUniqueCourseCodesFromData(allMemoFiles)
     if (courseCodes && courseCodes.length > 0) {
@@ -105,11 +106,16 @@ async function _fetchAllMemoFilesAndUpdateWithApplicationCodes() {
         if (safeGet(() => apiResponse.message)) {
           log.debug('Error from API trying to update a new memo file: ', apiResponse.message)
           failedMemoFilesToUpdate.push(memoFile)
+        } else {
+          memoFilesUpdated.push(memoFile)
         }
         log.info('New memo file was created in kurs-pm-data-api for course memo with id:', _id)
       }
     }
   }
+  log.debug('Total fetced memos files', allMemoFiles.length)
+  log.debug('Total memo update calls', memoFilesUpdated.length)
+  log.debug('Total failed memos files', failedMemoFilesToUpdate.length)
   if (failedMemoFilesToUpdate.length > 0) {
     _exportToCsv('failed_memo_files.csv', failedMemoFilesToUpdate)
   }
@@ -117,6 +123,7 @@ async function _fetchAllMemoFilesAndUpdateWithApplicationCodes() {
 
 async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
   const failedMemosToUpdate = []
+  const memosUpdated = []
   const memoData = await getMemoApiData('getAllMemos', null)
   if (memoData && memoData.length > 0) {
     const courseCodes = _getAllUniqueCourseCodesFromData(memoData)
@@ -156,12 +163,17 @@ async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
           if (safeGet(() => apiResponse.message)) {
             log.debug('Error from API trying to update a new draft: ', apiResponse.message)
             failedMemosToUpdate.push(memo)
+          } else {
+            memosUpdated.push(memo)
+            log.info('New memo draft was created in kurs-pm-data-api for course memo with memoEndPoint:', memoEndPoint)
           }
-          log.info('New memo draft was created in kurs-pm-data-api for course memo with memoEndPoint:', memoEndPoint)
         }
       }
     }
   }
+  log.debug('Total fetced memos', memoData.length)
+  log.debug('Total memos updated', memosUpdated.length)
+  log.debug('Total failed memos', failedMemosToUpdate.length)
   if (failedMemosToUpdate.length > 0) {
     _exportToCsv('failed_memos.csv', failedMemosToUpdate)
   }

--- a/server/controllers/updateMemosCtrl.js
+++ b/server/controllers/updateMemosCtrl.js
@@ -20,23 +20,20 @@ async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
         const { lastTermsInfo } = await getKoppsCourseRoundTerms(courseCode, false)
         if (lastTermsInfo && lastTermsInfo.length > 0) {
           for await (const { ladokRoundIds, semester, applicationCodes, memoEndPoint } of memoData) {
-            for await (const { rounds, term } of lastTermsInfo) {
-              if (semester.toString() === term.toString()) {
-                for await (const ladokRoundId of ladokRoundIds) {
-                  const round = rounds.find(x => x.ladokRoundId.toString() === ladokRoundId.toString())
-                  if (round) {
-                    const { ladokUID } = round
-                    if (ladokUID && ladokUID !== '') {
-                      if (courseCode === 'SF1626' && ladokRoundId === '7' && semester === '20211') {
-                        log.info('Check')
-                      }
-                      const { application_code, round_number } = await getApplicationFromLadokUID(ladokUID)
-                      totalApplicationCodesFetchedFromKopps++
-                      if (round_number.toString() === ladokRoundId.toString()) {
-                        const applicationCode = applicationCodes.find(x => x.toString() === application_code.toString())
-                        if (!applicationCode) {
-                          applicationCodes.push(application_code)
-                        }
+            const lastTermInfo = lastTermsInfo.find(x => x.term.toString() === semester.toString())
+            if (lastTermInfo) {
+              const { rounds } = lastTermInfo
+              for await (const ladokRoundId of ladokRoundIds) {
+                const round = rounds.find(x => x.ladokRoundId.toString() === ladokRoundId.toString())
+                if (round) {
+                  const { ladokUID } = round
+                  if (ladokUID && ladokUID !== '') {
+                    const { application_code, round_number } = await getApplicationFromLadokUID(ladokUID)
+                    totalApplicationCodesFetchedFromKopps++
+                    if (round_number.toString() === ladokRoundId.toString()) {
+                      const applicationCode = applicationCodes.find(x => x.toString() === application_code.toString())
+                      if (!applicationCode) {
+                        applicationCodes.push(application_code)
                       }
                     }
                   }

--- a/server/controllers/updateMemosCtrl.js
+++ b/server/controllers/updateMemosCtrl.js
@@ -176,7 +176,7 @@ async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
               try {
                 const apiResponse = await changeMemoApiData(
                   'updatedMemoWithApplicationCodes',
-                  { courseCode, semester, memoEndPoint, memoStatus },
+                  { courseCode, semester, memoEndPoint, status: memoStatus },
                   { applicationCodes, ladokRoundIds }
                 )
                 if (safeGet(() => apiResponse.message)) {

--- a/server/controllers/updateMemosCtrl.js
+++ b/server/controllers/updateMemosCtrl.js
@@ -2,68 +2,128 @@
 
 const { safeGet } = require('safe-utils')
 const log = require('@kth/log')
-const { getKoppsCourseRoundTerms, getAllCourseCodes, getApplicationFromLadokUID } = require('../koppsApi')
+const { getKoppsCourseRoundTerms, getApplicationFromLadokUID } = require('../koppsApi')
 const { getMemoApiData, changeMemoApiData } = require('../kursPmDataApi')
 
-async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
-  const courseCodes = await getAllCourseCodes()
-  let totalMemosToUpdate = 0
-  let totalCoursesFetchedFromKopps = 0
-  let totalApplicationCodesFetchedFromKopps = 0
-  if (courseCodes && courseCodes.length > 0) {
-    totalCoursesFetchedFromKopps = courseCodes.length
-    for await (const courseCode of courseCodes) {
-      const memoData = await getMemoApiData('getAllMemosByCourseCode', {
-        courseCode,
-      })
-      if (memoData && memoData.length > 0) {
-        const { lastTermsInfo } = await getKoppsCourseRoundTerms(courseCode, false)
+function _getAllUniqueCourseCodesFromData(data) {
+  const courseCodes = []
+  data.forEach(({ courseCode }) => {
+    const isCourseCodeAlreadyExist = courseCodes.some(x => x === courseCode)
+    if (!isCourseCodeAlreadyExist) {
+      courseCodes.push(courseCode)
+    }
+  })
+  return courseCodes
+}
+
+async function _getCourseRoundTermMap(courseCodes) {
+  const courseRoundTermMap = new Map()
+  log.debug('Total courses to fetch course rounds', courseCodes.length)
+  for await (const courseCode of courseCodes) {
+    log.debug('Fetching course round terms for course: ', courseCode)
+    const { lastTermsInfo } = await getKoppsCourseRoundTerms(courseCode, false)
+    courseRoundTermMap.set(courseCode, lastTermsInfo)
+  }
+  return courseRoundTermMap
+}
+
+async function _fetchAllMemoFilesAndUpdateWithApplicationCodes() {
+  const allMemoFiles = await getMemoApiData('getStoredMemoPdfList', null)
+  if (allMemoFiles && allMemoFiles.length > 0) {
+    const courseCodes = _getAllUniqueCourseCodesFromData(allMemoFiles)
+    if (courseCodes && courseCodes.length > 0) {
+      const courseRoundTermsMap = await _getCourseRoundTermMap(courseCodes)
+      for await (const memoFile of allMemoFiles) {
+        let { applicationCode } = memoFile
+        const { _id, courseCode, koppsRoundId, semester } = memoFile
+        const lastTermsInfo = courseRoundTermsMap.get(courseCode)
         if (lastTermsInfo && lastTermsInfo.length > 0) {
-          for await (const { ladokRoundIds, semester, applicationCodes, memoEndPoint, _id } of memoData) {
-            const lastTermInfo = lastTermsInfo.find(x => x.term.toString() === semester.toString())
-            if (lastTermInfo) {
-              const { rounds } = lastTermInfo
-              for await (const ladokRoundId of ladokRoundIds) {
-                const round = rounds.find(x => x.ladokRoundId.toString() === ladokRoundId.toString())
-                if (round) {
-                  const { ladokUID } = round
-                  if (ladokUID && ladokUID !== '') {
-                    const { application_code, round_number } = await getApplicationFromLadokUID(ladokUID)
-                    totalApplicationCodesFetchedFromKopps++
-                    if (round_number.toString() === ladokRoundId.toString()) {
-                      const applicationCode = applicationCodes.find(x => x.toString() === application_code.toString())
-                      if (!applicationCode) {
-                        applicationCodes.push(application_code)
-                      }
+          const lastTermInfo = lastTermsInfo.find(x => x.term.toString() === semester.toString())
+          if (lastTermInfo) {
+            const { rounds } = lastTermInfo
+            const round = rounds.find(x => x.ladokRoundId.toString() === koppsRoundId.toString())
+            if (round) {
+              const { ladokUID } = round
+              if (ladokUID && ladokUID !== '') {
+                const { application_code, round_number } = await getApplicationFromLadokUID(ladokUID)
+                if (round_number.toString() === koppsRoundId.toString()) {
+                  applicationCode = application_code
+                }
+              }
+            }
+          }
+        }
+        const apiResponse = await changeMemoApiData(
+          'updateStoredPdfMemoWithApplicationCodes',
+          { _id },
+          { applicationCode }
+        )
+        if (safeGet(() => apiResponse.message)) {
+          log.debug('Error from API trying to update a new memo file: ', apiResponse.message)
+        }
+        log.info('New memo file was created in kurs-pm-data-api for course memo with id:', _id)
+      }
+    }
+  }
+}
+
+async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
+  let totalMemosToUpdate = 0
+  let totalApplicationCodesFetchedFromKopps = 0
+  const skipMemoMap = new Map()
+  const memoData = await getMemoApiData('getAllMemos', null)
+  if (memoData && memoData.length > 0) {
+    const courseCodes = _getAllUniqueCourseCodesFromData(memoData)
+    if (courseCodes && courseCodes.length > 0) {
+      const courseRoundTermsMap = await _getCourseRoundTermMap(courseCodes)
+      for await (const memo of memoData) {
+        const { courseCode, ladokRoundIds, semester, applicationCodes, memoEndPoint, status } = memo
+        const lastTermsInfo = courseRoundTermsMap.get(courseCode)
+        if (lastTermsInfo) {
+          const lastTermInfo = lastTermsInfo.find(x => x.term.toString() === semester.toString())
+          if (lastTermInfo) {
+            const { rounds } = lastTermInfo
+            for await (const ladokRoundId of ladokRoundIds) {
+              const round = rounds.find(x => x.ladokRoundId.toString() === ladokRoundId.toString())
+              if (round) {
+                const { ladokUID } = round
+                if (ladokUID && ladokUID !== '') {
+                  const { application_code, round_number } = await getApplicationFromLadokUID(ladokUID)
+                  totalApplicationCodesFetchedFromKopps++
+                  if (round_number.toString() === ladokRoundId.toString()) {
+                    const applicationCode = applicationCodes.find(x => x.toString() === application_code.toString())
+                    if (!applicationCode) {
+                      applicationCodes.push(application_code)
                     }
                   }
                 }
               }
             }
-            const apiResponse = await changeMemoApiData(
-              'updatedMemoById',
-              { _id },
-              {
-                applicationCodes,
-              }
-            )
-            if (safeGet(() => apiResponse.message)) {
-              log.debug('Error from API trying to update a new draft: ', apiResponse.message)
-            }
-            log.info('New memo draft was created in kurs-pm-data-api for course memo with memoEndPoint:', memoEndPoint)
-            totalMemosToUpdate++
           }
+          const apiResponse = await changeMemoApiData(
+            'updatedMemoWithApplicationCodes',
+            { courseCode, semester, memoEndPoint, ladokRoundIds, status },
+            { applicationCodes }
+          )
+          if (safeGet(() => apiResponse.message)) {
+            log.debug('Error from API trying to update a new draft: ', apiResponse.message)
+          }
+          log.info('New memo draft was created in kurs-pm-data-api for course memo with memoEndPoint:', memoEndPoint)
+          totalMemosToUpdate++
+        } else {
+          skipMemoMap.set(courseCode, { lastTermsInfo, memo })
         }
       }
     }
-    log.debug('All memos have been updated with application codes.', {
-      totalApplicationCodesFetchedFromKopps,
-      totalCoursesFetchedFromKopps,
-      totalMemosToUpdate,
-    })
   }
+  log.debug('All memos have been updated with application codes.', {
+    totalApplicationCodesFetchedFromKopps,
+    totalMemosToUpdate,
+    skipMemoMap,
+  })
 }
 
 module.exports = {
   fetchAllMemosAndUpdateMemoWithApplicationCodes: _fetchAllMemosAndUpdateMemoWithApplicationCodes,
+  fetchAllMemoFilesAndUpdateWithApplicationCodes: _fetchAllMemoFilesAndUpdateWithApplicationCodes,
 }

--- a/server/controllers/updateMemosCtrl.js
+++ b/server/controllers/updateMemosCtrl.js
@@ -168,6 +168,9 @@ async function _fetchAllMemosAndUpdateMemoWithApplicationCodes() {
                     log.debug('LadokUID not found from round:', { round }, { memo })
                     memosWithOutApplicationCodes.push(memo)
                   }
+                } else {
+                  log.debug('No round matched', { ladokRoundId })
+                  memosWithOutApplicationCodes.push(memo)
                 }
               }
               try {

--- a/server/koppsApi.js
+++ b/server/koppsApi.js
@@ -111,23 +111,6 @@ async function getApplicationFromLadokUID(ladokUID) {
   }
 }
 
-// No need to merge this method to master
-async function getAllCourseCodes() {
-  const { client } = api.koppsApi
-  const uri = `${config.koppsApi.basePath}courses`
-  try {
-    const { body: courses, statusCode } = await client.getAsync({ uri, useCache: true })
-    if (!courses || statusCode !== 200) return 'kopps_get_fails'
-    const courseCodes = []
-    courses.forEach(({ code }) => {
-      courseCodes.push(code)
-    })
-    return courseCodes
-  } catch (err) {
-    return err
-  }
-}
-
 async function getCourseSchool(courseCode) {
   const { client } = api.koppsApi
   const uri = `${config.koppsApi.basePath}course/${encodeURIComponent(courseCode)}`
@@ -356,7 +339,6 @@ async function getSyllabus(courseCode, semester, language = 'sv') {
 
 module.exports = {
   koppsApi: api,
-  getAllCourseCodes,
   getCourseSchool,
   getKoppsCourseRoundTerms,
   getSyllabus,

--- a/server/kursPmDataApi.js
+++ b/server/kursPmDataApi.js
@@ -10,8 +10,10 @@ const clientActions = {
   deleteDraftByMemoEndPoint: 'delAsync',
   updateCreatedDraft: 'putAsync',
   // No need to merge these two methods to master
-  updatedMemoById: 'putAsync',
-  getAllMemosByCourseCode: 'getAsync',
+  updatedMemoWithApplicationCodes: 'putAsync',
+  getAllMemos: 'getAsync',
+  getStoredMemoPdfList: 'getAsync',
+  updateStoredPdfMemoWithApplicationCodes: 'putAsync',
 }
 // Gets a list of used round ids for a semester in a course
 async function getMemoApiData(apiFnName, uriParam) {

--- a/server/kursPmDataApi.js
+++ b/server/kursPmDataApi.js
@@ -9,6 +9,9 @@ const clientActions = {
   publishMemoByEndPoint: 'postAsync',
   deleteDraftByMemoEndPoint: 'delAsync',
   updateCreatedDraft: 'putAsync',
+  // No need to merge these two methods to master
+  updatedMemoById: 'putAsync',
+  getAllMemosByCourseCode: 'getAsync',
 }
 // Gets a list of used round ids for a semester in a course
 async function getMemoApiData(apiFnName, uriParam) {

--- a/server/ugRestApi.js
+++ b/server/ugRestApi.js
@@ -184,6 +184,7 @@ const _getMembersObjectFromGroups = (
 
 // ------- EXAMINATOR AND RESPONSIBLES FROM UG-REST_API: ------- /
 async function _getCourseEmployees(apiMemoData) {
+  return {}
   const { courseCode, semester, ladokRoundIds } = apiMemoData
   try {
     const { assistants, teachers, examiners, responsibles } = _groupNames(courseCode, semester, ladokRoundIds)

--- a/test/mocks/ApplicationStore.js
+++ b/test/mocks/ApplicationStore.js
@@ -9,10 +9,10 @@ const applicationStore = createApplicationStore()
 
 const tempSaveNewDraft = async (action, copyFrom, body, isTest) => {
   const newMemo = await applicationStore.createNewMemo(action, copyFrom, body, isTest) //function exist
-  const { ladokRoundIds, memoCommonLangAbbr, memoEndPoint, memoName, semester } = newMemo
+  const { applicationCodes, memoCommonLangAbbr, memoEndPoint, memoName, semester } = newMemo
   //Example where data saves
   const objToSave = {
-    ladokRoundIds,
+    applicationCodes,
     memoCommonLangAbbr,
     memoId: Math.random(),
     memoEndPoint,


### PR DESCRIPTION
1. Added methods to get all memos and memofiles from Api and update all documents with application codes.
2. Added method to add application codes that does not updated in Mongo collections.

**Note: Please do not merge this PR. It is only required to update Collections**