### PR TITLE
Bugfix: Application code on round has changed from array to string

### DIFF
--- a/public/js/app/components/ActionModalCourseRounds.jsx
+++ b/public/js/app/components/ActionModalCourseRounds.jsx
@@ -95,7 +95,7 @@ function ActionModalCourseRounds(props) {
   const _koppsInfoForChecked = sortedApplicationCodes => {
     const sortedKoppsInfo = []
     for (let i = 0; i < sortedApplicationCodes.length; i++) {
-      sortedKoppsInfo.push(allRounds.find(round => sortedApplicationCodes[i] === round.applicationCodes[0]))
+      sortedKoppsInfo.push(allRounds.find(round => sortedApplicationCodes[i] === round.applicationCode))
     }
     return sortedKoppsInfo
   }


### PR DESCRIPTION
The property applicationCodes on round seems to have changed from array to string.
Need to confirm if that is always the case or if it can be both - string and array.