### PR TITLE
fix/KUI-1396: fix date and version bugs in preview

### DIFF
--- a/public/js/app/components/preview/CourseFacts.jsx
+++ b/public/js/app/components/preview/CourseFacts.jsx
@@ -98,7 +98,7 @@ const startDate = (labels, memoData) =>
   memoData.roundsStartDate ? (
     <>
       <h3>{labels.startdate}</h3>
-      <p>{getDateFormat(memoData.roundsStartDate[0])}</p>
+      <p>{getDateFormat(memoData.roundsStartDate[0], memoData.languageOfInstructions)}</p>
     </>
   ) : (
     <>

--- a/public/js/app/components/preview/CourseMemoLinks.jsx
+++ b/public/js/app/components/preview/CourseMemoLinks.jsx
@@ -1,26 +1,24 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import { getDateFormat } from '../../util/helpers'
 import Popup from './Popup'
 
-const formatVersion = (language = 'sv', version) => {
-  const unixTime = Date.parse(version)
+const formatVersionDateAndTime = (language = 'sv', lastChangedDateTime) => {
+  const unixTime = Date.parse(lastChangedDateTime)
   if (unixTime) {
-    if (language === 'sv') {
-      return new Date(unixTime).toLocaleString('sv-SE')
-    } else {
-      const options = { day: 'numeric', month: 'short', year: 'numeric' }
-      return new Date(unixTime).toLocaleDateString('en-GB', options)
-    }
+    const date = new Date(unixTime)
+    const time = date.toLocaleTimeString()
+    return `${getDateFormat(date, language)}  ${time}`
   }
   return null
 }
 
-const version = (language, labels, memoVersion) =>
-  memoVersion ? (
+const version = (language, labels, lastChangedDateTime, memoData) =>
+  lastChangedDateTime ? (
     <>
       <h3>{labels.versionTitle}</h3>
-      <p>{`${labels.latest} ${formatVersion(language, memoVersion)}`}</p>
+      <p>{`Ver ${memoData.version} -  ${formatVersionDateAndTime(language, lastChangedDateTime)}`}</p>
     </>
   ) : (
     <>
@@ -41,7 +39,7 @@ const pdfLink = labels => (
 
 const CourseMemoLinks = ({ language, labels, memoData = {} }) => (
   <div className="info-box">
-    {version(language, labels, memoData.lastChangeDate)}
+    {version(language, labels, memoData.lastChangeDate, memoData)}
     {pdfLink(labels)}
   </div>
 )

--- a/public/js/app/util/helpers.js
+++ b/public/js/app/util/helpers.js
@@ -17,12 +17,12 @@ export const combinedCourseName = (courseCode, course, langAbbr) => {
 }
 
 export const getDateFormat = (date, language) => {
-  if (language === 1 || language === 'Svenska' || language === 'Swedish' || language === 'sv') {
-    return date
-  }
-  const options = { day: 'numeric', month: 'short', year: 'numeric' }
   const timestamp = Date.parse(date)
   const parsedDate = new Date(timestamp)
+  if (language === 1 || language === 'Svenska' || language === 'Swedish' || language === 'sv') {
+    return parsedDate.toLocaleDateString('sv')
+  }
+  const options = { day: 'numeric', month: 'short', year: 'numeric' }
   return parsedDate.toLocaleDateString('en-GB', options)
 }
 


### PR DESCRIPTION
Fixes for start date and version being displayed differently in preview and published course memos.

To test: 

1. Run this branch locally and open the admin tool for a course, e.g. `II1306` 
2. In REF, open an edit session for an already published memo for the same course` as above, e.g. here: https://app-r.referens.sys.kth.se/kursinfoadmin/kurs-pm-data/published/II1306`
3. Copy the part of the url from REF with info about course and memo draft id and paste it in the local url, e.g. `https://app-r.referens.sys.kth.se/kursinfoadmin/kurs-pm-data/II1306/II130620232-50133/preview`=> `http://localhost:3000/kursinfoadmin/kurs-pm-data/SF1624/II1306/II130620232-50133/preview`
4. Look at the preview for the draft open locally and compare it to the published version in REF, usually found in the archive: e.g. `https://app-r.referens.sys.kth.se/kursutveckling/II1306/arkiv`
5. Check that the start date is displayed the same between the two memos
6. Check that the version number of the new draft has increased by one compared to the published version seen in REF

Do the testing above for one memo with instruction language in Swedish and one with English. Check that the date format is adjusted depending on language of instruction.