### PR TITLE
feat(KUI-1938): remove hardcoded kopps course instance state (not used)

### DIFF
--- a/server/utils/formatLadokData.js
+++ b/server/utils/formatLadokData.js
@@ -26,7 +26,6 @@ const formatLadokData = (ladokCourseRounds, ladokCourseData) => {
       credits: ladokCourseData.omfattning,
       creditUnitLabel: ladokCourseData.utbildningstyp?.creditsUnit,
       creditUnitAbbr: ladokCourseData.utbildningstyp?.creditsUnit.code.toLowerCase(),
-      state: 'ESTABLISHED', // TODO: Handle state dynamically instead of hardcoding it
     },
     lastTermsInfo: groupedLadokCourseRounds,
   }

--- a/test/mock-api/responses.js
+++ b/test/mock-api/responses.js
@@ -82,7 +82,6 @@ module.exports = {
       credits: 7.5,
       creditUnitLabel: 'Högskolepoäng',
       creditUnitAbbr: 'hp',
-      state: 'ESTABLISHED',
     },
     examiners: [
       {

--- a/test/mocks/miniLadokObjs.js
+++ b/test/mocks/miniLadokObjs.js
@@ -23,7 +23,6 @@ export const mockMiniLadokObj = {
           firstTuitionDate: '2021-01-18',
           language: { sv: 'Engelska', en: 'English' },
           applicationCode: '22222',
-          state: 'CANCELLED',
         },
         {
           // todo: add as course round
@@ -324,7 +323,6 @@ export const mockMiniLadokObjEn = {
           firstTuitionDate: '2021-01-18',
           language: { sv: 'Engelska', en: 'English' },
           applicationCode: '22222',
-          state: 'CANCELLED',
         },
         {
           // todo: add as course round

--- a/test/mocks/mockLadokCourseRounds.js
+++ b/test/mocks/mockLadokCourseRounds.js
@@ -131,7 +131,6 @@ const formattedData = {
     credits: '7.5',
     creditUnitLabel: { code: 'HP', sv: 'Högskolepoäng', en: 'Credits' },
     creditUnitAbbr: 'hp',
-    state: 'ESTABLISHED',
   },
   lastTermsInfo: groupedLadokCourseRounds,
 }


### PR DESCRIPTION
## 📌 Summary

<!-- Explain what this PR does and why. Link issues if relevant. -->

Fixes https://kth-se.atlassian.net/browse/KUI-1938


---

## 🔍 Changes

<!-- Bullet points of main changes -->

- Removed unused `state` field which is an old remnant from KOPPS. Not used anymore in the logic as it has been replaced by Ladok fields.

---

## ✅ Checklist (Author)

- [x] Code builds locally without errors
- [x] Tests added/updated and passing
- [x] Linting/formatting applied
- [x] No sensitive data in the diff
- [x] No stray console.logs in the diff
- [x] No stray comments in the diff
- [x] Docs/README/CHANGELOG updated (if needed)
- [x] Sufficient logging
- [x] Errors are handled accordingly

---

## 🧪 Testing & Verification

1. Ran locally and clicked around
2. `npm test` ran without errors


---

## ⚠️ Impact / Risks

\-

---

## 🚧 Out of Scope

\-

---

## 📦 Downstream apps

\-